### PR TITLE
Forward billing email to checkout page & Add 'Do nothing' option

### DIFF
--- a/coingate.php
+++ b/coingate.php
@@ -204,7 +204,7 @@ function coingate_init()
                 $wcCanceledStatus = $orderStatuses['canceled'];
 
                 if ($wcOrderStatus == 'do-nothing') {
-					$order->add_order_note(__('CoinGate moved the invoice in their system to ' . $cgOrder->status . ', but no local changes were made.', 'coingate'));
+                    $order->add_order_note(__('CoinGate moved the invoice in their system to ' . $cgOrder->status . ', but no local changes were made.', 'coingate'));
                 } else {
                     switch ($cgOrder->status) {
                         case 'paid':


### PR DESCRIPTION
- Forward billing email to CoinGate checkout page because customers didn't receive any payment emails
- Add 'Do nothing' option to invoice status updates because CoinGate randomly changes the invoice status to expired after it has been marked as completed
- Remove unused variables
- Fix deprecated WooCommerce calls

I reported these issues to the CoinGate support team _9 months ago_, but they didn't do anything to fix them.