### PR TITLE
fix #11 : For fresh installation of v2 not showing payment settings page

### DIFF
--- a/includes/class-coingate-for-woocommerce-payment-gateway.php
+++ b/includes/class-coingate-for-woocommerce-payment-gateway.php
@@ -346,7 +346,7 @@ class Coingate_Payment_Gateway extends WC_Payment_Gateway
                                     $order_statuses = $cg_settings['order_statuses'];
 
                                     foreach ($wc_statuses as $wc_status_name => $wc_status_title) {
-                                        $current_status = $order_statuses[$cg_status_name];
+                                        $current_status = isset( $order_statuses[$cg_status_name] ) ? $order_statuses[$cg_status_name] : "";
 
                                         if (empty($current_status))
                                             $current_status = $default_statuses[$cg_status_name];


### PR DESCRIPTION
Added check for array key using `isset` instead of directly trying to access the key. For the initial phase of installation, there is a time when `$order_statuses` is just an empty string. In line `349` it's always considered as an array and the key is being accessed. That's creating a fatal error.